### PR TITLE
Lcf partition tree 0905

### DIFF
--- a/compile_error
+++ b/compile_error
@@ -1,0 +1,2 @@
+Makefile:156: Warning: Compiling in debug mode. Don't use the resulting binary in production
+Makefile:156: Warning: Compiling in debug mode. Don't use the resulting binary in production

--- a/compile_error
+++ b/compile_error
@@ -1,2 +1,0 @@
-Makefile:156: Warning: Compiling in debug mode. Don't use the resulting binary in production
-Makefile:156: Warning: Compiling in debug mode. Don't use the resulting binary in production

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1441,6 +1441,11 @@ bool ColumnFamilySet::AddLogicalColumnFamily(ColumnFamilyData* c_in) {
 
 // under a DB mutex AND write thread
 bool ColumnFamilySet::SplitLogicalColumnFamily(ColumnFamilyData* c_in, ColumnFamilyData* c_out_0, ColumnFamilyData* c_out_1) {
+  std::vector<ColumnFamilyData*> c_outs = {c_out_0, c_out_1};
+
+  partition_tree_.InsertSplittedColumnFamily(c_in, c_outs);
+
+  /*
   // find c_in
   int l = 0;
   int r = logical_column_family_data_.size();
@@ -1469,6 +1474,7 @@ bool ColumnFamilySet::SplitLogicalColumnFamily(ColumnFamilyData* c_in, ColumnFam
   } else { // not found
     return false;
   }
+  */
 }
 
 void ColumnFamilySet::PrintLogicalColumnFamily(void) {
@@ -1503,6 +1509,7 @@ ColumnFamilyData* ColumnFamilySet::CreateColumnFamily(
   dummy_cfd_->prev_ = new_cfd;
   if (id == 0) {
     default_cfd_cache_ = new_cfd;
+    partition_tree_.SetRootColumnFamily(new_cfd);
   }
   return new_cfd;
 }
@@ -1529,6 +1536,7 @@ ColumnFamilyData* ColumnFamilySet::CreateColumnFamily(
   dummy_cfd_->prev_ = new_cfd;
   if (id == 0) {
     default_cfd_cache_ = new_cfd;
+    partition_tree_.SetRootColumnFamily(new_cfd);
   }
   return new_cfd;
 }

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1402,6 +1402,9 @@ size_t ColumnFamilySet::NumberOfColumnFamilies() const {
 
 // under a DB mutex AND write thread
 bool ColumnFamilySet::AddLogicalColumnFamily(ColumnFamilyData* c_in) {
+
+  return c_in != nullptr;
+  /*
   // find c_in
   int l = 0;
   int r = logical_column_family_data_.size();
@@ -1436,7 +1439,7 @@ bool ColumnFamilySet::AddLogicalColumnFamily(ColumnFamilyData* c_in) {
     return true;
   } else { // not found
     return false;
-  }
+  }*/
 }
 
 // under a DB mutex AND write thread
@@ -1481,10 +1484,14 @@ bool ColumnFamilySet::SplitLogicalColumnFamily(ColumnFamilyData* c_in, ColumnFam
 
 void ColumnFamilySet::PrintLogicalColumnFamily(void) {
   fprintf(stdout, "=======PrintLogicalColumnFamily=======\n");
-  for (auto c: logical_column_family_data_) {
+
+  partition_tree_->PrintAll();
+  
+  /*
+  for (auto c: partition_tree_->) {
     fprintf(stdout, "LCF[%d] %s => [%s, %s)\n", c->GetID(), c->GetName().c_str()
                                               , c->GetSmallestKey().c_str(), c->GetLargestKey().c_str());
-  }
+  }*/
   fprintf(stdout, "======================================\n");
 }
 /*

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1445,6 +1445,8 @@ bool ColumnFamilySet::SplitLogicalColumnFamily(ColumnFamilyData* c_in, ColumnFam
 
   partition_tree_.InsertSplittedColumnFamily(c_in, c_outs);
 
+  return true;
+  
   /*
   // find c_in
   int l = 0;
@@ -1485,9 +1487,13 @@ void ColumnFamilySet::PrintLogicalColumnFamily(void) {
   }
   fprintf(stdout, "======================================\n");
 }
-
+/*
 std::vector<ColumnFamilyData*> ColumnFamilySet::GetLogicalColumnFamily(void) {
   return logical_column_family_data_;
+}*/
+
+ColumnFamilyData* ColumnFamilySet::GetLogicalColumnFamily(const Slice &key) {
+  return partition_tree_.SearchColumnFamily(key);
 }
 
 // under a DB mutex AND write thread
@@ -1589,6 +1595,10 @@ MemTable* ColumnFamilyMemTablesImpl::GetMemTable() const {
 ColumnFamilyHandle* ColumnFamilyMemTablesImpl::GetColumnFamilyHandle() {
   assert(current_ != nullptr);
   return &handle_;
+}
+
+ColumnFamilyData* ColumnFamilyMemTablesImpl::SeekLogicalColumnFamily(const Slice &key) {
+  return column_family_set_->GetLogicalColumnFamily(key);
 }
 
 uint32_t GetColumnFamilyID(ColumnFamilyHandle* column_family) {

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1443,7 +1443,7 @@ bool ColumnFamilySet::AddLogicalColumnFamily(ColumnFamilyData* c_in) {
 bool ColumnFamilySet::SplitLogicalColumnFamily(ColumnFamilyData* c_in, ColumnFamilyData* c_out_0, ColumnFamilyData* c_out_1) {
   std::vector<ColumnFamilyData*> c_outs = {c_out_0, c_out_1};
 
-  partition_tree_.InsertSplittedColumnFamily(c_in, c_outs);
+  partition_tree_->InsertSplittedColumnFamily(c_in, c_outs);
 
   return true;
   
@@ -1493,7 +1493,7 @@ std::vector<ColumnFamilyData*> ColumnFamilySet::GetLogicalColumnFamily(void) {
 }*/
 
 ColumnFamilyData* ColumnFamilySet::GetLogicalColumnFamily(const Slice &key) {
-  return partition_tree_.SearchColumnFamily(key);
+  return partition_tree_->SearchColumnFamily(key);
 }
 
 // under a DB mutex AND write thread
@@ -1515,7 +1515,7 @@ ColumnFamilyData* ColumnFamilySet::CreateColumnFamily(
   dummy_cfd_->prev_ = new_cfd;
   if (id == 0) {
     default_cfd_cache_ = new_cfd;
-    partition_tree_.SetRootColumnFamily(new_cfd);
+    partition_tree_ = new PartitionTree(new_cfd);
   }
   return new_cfd;
 }
@@ -1542,7 +1542,7 @@ ColumnFamilyData* ColumnFamilySet::CreateColumnFamily(
   dummy_cfd_->prev_ = new_cfd;
   if (id == 0) {
     default_cfd_cache_ = new_cfd;
-    partition_tree_.SetRootColumnFamily(new_cfd);
+    partition_tree_ = new PartitionTree(new_cfd);
   }
   return new_cfd;
 }

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -435,6 +435,7 @@ ColumnFamilyData::ColumnFamilyData(
       column_family_set_(column_family_set),
       queued_for_flush_(false),
       queued_for_compaction_(false),
+      queued_for_split_(false),
       prev_compaction_needed_bytes_(0),
       allow_2pc_(db_options.allow_2pc),
       last_memtable_id_(0) {
@@ -526,6 +527,7 @@ ColumnFamilyData::ColumnFamilyData(
       column_family_set_(column_family_set),
       queued_for_flush_(false),
       queued_for_compaction_(false),
+      queued_for_split_(false),
       prev_compaction_needed_bytes_(0),
       allow_2pc_(db_options.allow_2pc),
       last_memtable_id_(0) {

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -46,6 +46,7 @@ class LogBuffer;
 class InstrumentedMutex;
 class InstrumentedMutexLock;
 struct SuperVersionContext;
+class PartitionTree;
 
 extern const double kIncSlowdownRatio;
 
@@ -620,7 +621,7 @@ class ColumnFamilySet {
   std::unordered_map<uint32_t, ColumnFamilyData*> column_family_data_;
   int comp_smallest_key (ColumnFamilyData* c1, ColumnFamilyData* c2) { return c1->GetSmallestKey().compare(c2->GetSmallestKey()); };
   std::vector<ColumnFamilyData*> logical_column_family_data_;
-  PartitionTree partition_tree_;
+  PartitionTree* partition_tree_;
 
   uint32_t max_column_family_;
   ColumnFamilyData* dummy_cfd_;

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -620,7 +620,7 @@ class ColumnFamilySet {
   std::unordered_map<std::string, uint32_t> column_families_;
   std::unordered_map<uint32_t, ColumnFamilyData*> column_family_data_;
   int comp_smallest_key (ColumnFamilyData* c1, ColumnFamilyData* c2) { return c1->GetSmallestKey().compare(c2->GetSmallestKey()); };
-  std::vector<ColumnFamilyData*> logical_column_family_data_;
+  //std::vector<ColumnFamilyData*> logical_column_family_data_;
   PartitionTree* partition_tree_;
 
   uint32_t max_column_family_;

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -25,6 +25,9 @@
 #include "rocksdb/env.h"
 #include "rocksdb/options.h"
 #include "util/thread_local.h"
+
+#include "db/partition_tree.h"
+
 namespace rocksdb {
 
 class Version;
@@ -614,6 +617,7 @@ class ColumnFamilySet {
   std::unordered_map<uint32_t, ColumnFamilyData*> column_family_data_;
   int comp_smallest_key (ColumnFamilyData* c1, ColumnFamilyData* c2) { return c1->GetSmallestKey().compare(c2->GetSmallestKey()); };
   std::vector<ColumnFamilyData*> logical_column_family_data_;
+  PartitionTree partition_tree_;
 
   uint32_t max_column_family_;
   ColumnFamilyData* dummy_cfd_;

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -329,6 +329,8 @@ class ColumnFamilyData {
     return &int_tbl_prop_collector_factories_;
   }
 
+  ColumnFamilySet* GetColumnFamilySet() { return column_family_set_; }
+
   SuperVersion* GetSuperVersion() { return super_version_; }
   // thread-safe
   // Return a already referenced SuperVersion to be used safely.
@@ -579,7 +581,7 @@ class ColumnFamilySet {
   bool AddLogicalColumnFamily(ColumnFamilyData* c_in); // return true if successfully update lcf vector 
   bool SplitLogicalColumnFamily(ColumnFamilyData* c_in, ColumnFamilyData* c_out_0, ColumnFamilyData* c_out_1); // return true if successfully update lcf vector 
   void PrintLogicalColumnFamily(void);
-  std::vector<ColumnFamilyData*> GetLogicalColumnFamily(void);
+  //std::vector<ColumnFamilyData*> GetLogicalColumnFamily(void);
 
   ColumnFamilyData* CreateColumnFamily(const std::string& name, uint32_t id,
                                        Version* dummy_version,
@@ -600,6 +602,7 @@ class ColumnFamilySet {
 
   Cache* get_table_cache() { return table_cache_; }
 
+  ColumnFamilyData* GetLogicalColumnFamily(const Slice &key);
  private:
   friend class ColumnFamilyData;
   // helper function that gets called from cfd destructor
@@ -671,6 +674,8 @@ class ColumnFamilyMemTablesImpl : public ColumnFamilyMemTables {
   // REQUIRES: use this function of DBImpl::column_family_memtables_ should be
   //           under a DB mutex OR from a write thread
   virtual ColumnFamilyData* current() override { return current_; }
+
+  virtual ColumnFamilyData* SeekLogicalColumnFamily(const Slice &key) override;
 
  private:
   ColumnFamilySet* column_family_set_;

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1431,6 +1431,11 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
   auto cfs = cfd->GetColumnFamilySet();
   cfd = cfs->GetLogicalColumnFamily(key);
 
+  ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                 "GetImpl key : %s (ID %d)",
+                  key.ToString().c_str(),
+                  cfd->GetID());
+
   if (tracer_) {
     // TODO: This mutex should be removed later, to improve performance when
     // tracing is enabled.
@@ -1442,6 +1447,9 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
 
   // Acquire SuperVersion
   SuperVersion* sv = GetAndRefSuperVersion(cfd);
+  ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                 "GetImpl sv current : %s",
+                 sv->current->DebugString(true, true).c_str());
 
   TEST_SYNC_POINT("DBImpl::GetImpl:1");
   TEST_SYNC_POINT("DBImpl::GetImpl:2");
@@ -1500,6 +1508,10 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
       done = true;
       pinnable_val->PinSelf();
       RecordTick(stats_, MEMTABLE_HIT);
+
+      ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                     "GetImpl: mem");
+
     } else if ((s.ok() || s.IsMergeInProgress()) &&
                sv->imm->Get(lkey, pinnable_val->GetSelf(), &s, &merge_context,
                             &max_covering_tombstone_seq, read_options, callback,
@@ -1507,6 +1519,10 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
       done = true;
       pinnable_val->PinSelf();
       RecordTick(stats_, MEMTABLE_HIT);
+
+      ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                     "GetImpl: imm");
+
     }
     if (!done && !s.ok() && !s.IsMergeInProgress()) {
       ReturnAndCleanupSuperVersion(cfd, sv);
@@ -1519,6 +1535,9 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
                      &max_covering_tombstone_seq, value_found, nullptr, nullptr,
                      callback, is_blob_index);
     RecordTick(stats_, MEMTABLE_MISS);
+    ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                   "GetImpl: sst");
+
   }
 
   {

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -1424,6 +1424,10 @@ Status DBImpl::GetImpl(const ReadOptions& read_options,
   auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(column_family);
   auto cfd = cfh->cfd();
 
+  // Dohyun Kim: Partition Tree Search (NO Mutex)
+  auto cfs = cfd->GetColumnFamilySet();
+  cfd = cfs->GetLogicalColumnFamily(key);
+
   if (tracer_) {
     // TODO: This mutex should be removed later, to improve performance when
     // tracing is enabled.
@@ -2249,6 +2253,7 @@ void DBImpl::PrintLogicalColumnFamily(void) {
   return;
 }
 
+/*
 std::vector<ColumnFamilyData*> DBImpl::GetLogicalColumnFamily(void) {
   std::vector<ColumnFamilyData*> lcf;
   {
@@ -2257,7 +2262,7 @@ std::vector<ColumnFamilyData*> DBImpl::GetLogicalColumnFamily(void) {
     lcf = column_family_set->GetLogicalColumnFamily();
   }
   return lcf;
-}
+}*/
 
 
 Status DBImpl::CreateColumnFamilyImpl(const ColumnFamilyOptions& cf_options,

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -183,11 +183,14 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
       last_batch_group_size_(0),
       unscheduled_flushes_(0),
       unscheduled_compactions_(0),
+      unscheduled_splits_(0),
       bg_bottom_compaction_scheduled_(0),
       bg_compaction_scheduled_(0),
       num_running_compactions_(0),
       bg_flush_scheduled_(0),
       num_running_flushes_(0),
+      bg_split_scheduled_(0),
+      num_running_splits_(0),
       bg_purge_scheduled_(0),
       disable_delete_obsolete_files_(0),
       pending_purge_obsolete_files_(0),
@@ -2148,13 +2151,10 @@ Status DBImpl::SplitColumnFamilyImpl(const ColumnFamilyOptions& cf_options,
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "Created column family [%s] (ID %u)",
                      out0_name.c_str(), (unsigned)cfd0->GetID());
-
       *handle_out1 = new ColumnFamilyHandleImpl(cfd1, this, &mutex_);
       ROCKS_LOG_INFO(immutable_db_options_.info_log,
                      "Created column family [%s] (ID %u)",
                      out1_name.c_str(), (unsigned)cfd1->GetID());
-
-
     } else {
       ROCKS_LOG_ERROR(immutable_db_options_.info_log,
                       "Splitting column family [%s] FAILED -- %s",

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -752,7 +752,7 @@ class DBImpl : public DB {
 
 
   void PrintLogicalColumnFamily(void);
-  std::vector<ColumnFamilyData*> GetLogicalColumnFamily(void);
+  //std::vector<ColumnFamilyData*> GetLogicalColumnFamily(void);
 
  protected:
   Env* const env_;

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -2656,6 +2656,12 @@ Status DBImpl::BackgroundSplit(bool* made_progress,
       InstallSuperVersionAndScheduleWork(c->column_family_data(),
                                          &job_context->superversion_contexts[0],
                                          *c->mutable_cf_options());
+      InstallSuperVersionAndScheduleWork(c->column_family_data()->children_cfds[0],
+                                         &job_context->superversion_contexts[0],
+                                         *c->mutable_cf_options());
+      InstallSuperVersionAndScheduleWork(c->column_family_data()->children_cfds[1],
+                                         &job_context->superversion_contexts[0],
+                                         *c->mutable_cf_options());
     }
     *made_progress = true;
     TEST_SYNC_POINT_CALLBACK("DBImpl::BackgroundSplit:AfterSplit",

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -2074,6 +2074,13 @@ void DBImpl::SchedulePendingCompaction(ColumnFamilyData* cfd) {
 }
 
 void DBImpl::SchedulePendingSplit(ColumnFamilyData* cfd) {
+  ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                     "SchedulePendingSplit: is queued? : %d\n",
+                     cfd->queued_for_split());
+  ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                     "SchedulePendingSplit: need split? : %d\n",
+                     cfd->NeedsSplit());
+
   if (!cfd->queued_for_split() && cfd->NeedsSplit()) {
     AddToSplitQueue(cfd);
     ++unscheduled_splits_;

--- a/db/partition_tree.cc
+++ b/db/partition_tree.cc
@@ -36,8 +36,8 @@ PartitionTreeNode *PartitionTreeNode::SearchNextNode (
   for (auto nodes: lower_level_nodes_) {
     Slice right_most_key(get_rmost_key(nodes));
 
-    // Right most key is "" or key is less than or equal to right most key. 
-    if (right_most_key.empty() || key.compare(right_most_key) <= 0) { 
+    // Right most key is "" or key is less than right most key. 
+    if (right_most_key.empty() || key.compare(right_most_key) < 0) { 
 
       Slice left_most_key(get_lmost_key(nodes));
 

--- a/db/partition_tree.cc
+++ b/db/partition_tree.cc
@@ -31,10 +31,10 @@ PartitionTreeNode *PartitionTreeNode::SearchNextNode (
     return nullptr;
 
   // Linear Search
-  for (auto nodes: lower_level_nodes) {
+  for (auto nodes: lower_level_nodes_) {
     Slice right_most_key(get_rmost_key(nodes));
 
-    if (key.compare(right_most_key) =< 0) { 
+    if (key.compare(right_most_key) <= 0) { 
 
       Slice left_most_key(get_lmost_key(nodes));
 
@@ -50,7 +50,7 @@ PartitionTreeNode *PartitionTreeNode::SearchNextNode (
 
 // PartitionTree function.
 
-void PartitionTree::SetColumnFamily (
+void PartitionTree::SetRootColumnFamily (
     ColumnFamilyData* column_family_data) {
   root_.SetColumnFamily(column_family_data);
 }
@@ -59,8 +59,8 @@ void PartitionTree::InsertSplittedColumnFamily (
     ColumnFamilyData *base_cfd, 
     const std::vector<ColumnFamilyData*> &new_cfds) {
 
-  auto base_node = partition_nodes_.find(base_cfd->GetID());
-  bool push_back = base_node->lower_level_cfds_.empty();
+  auto base_node = partition_nodes_.find(base_cfd->GetID())->second;
+  bool push_back = base_node->lower_level_nodes_.empty();
 
   // TODO: check violation 1. 
   // Violation 1. The key range of splitted nodes under the base should be 
@@ -72,7 +72,7 @@ void PartitionTree::InsertSplittedColumnFamily (
     auto node = new PartitionTreeNode(new_cfd);
 
     if (push_back) {
-      base_node->lower_level_cfds_.push_back(node);
+      base_node->lower_level_nodes_.push_back(node);
       continue;
     } 
 
@@ -80,7 +80,7 @@ void PartitionTree::InsertSplittedColumnFamily (
   }
 }
 
-ColumnFamilyData *SearchColumnFamily (const Slice &key) {
+ColumnFamilyData* PartitionTree::SearchColumnFamily (const Slice &key) {
   PartitionTreeNode *cnode = &root_; // current node
   PartitionTreeNode *nnode = nullptr; // next node
 

--- a/db/partition_tree.cc
+++ b/db/partition_tree.cc
@@ -17,6 +17,8 @@ PartitionTreeNode::PartitionTreeNode (
     // TODO: error raise should be added. 
     return; 
   }
+
+  lower_level_nodes_ = {};
 } 
 
 void PartitionTreeNode::SetColumnFamily (
@@ -34,11 +36,13 @@ PartitionTreeNode *PartitionTreeNode::SearchNextNode (
   for (auto nodes: lower_level_nodes_) {
     Slice right_most_key(get_rmost_key(nodes));
 
-    if (key.compare(right_most_key) <= 0) { 
+    // Right most key is "" or key is less than or equal to right most key. 
+    if (right_most_key.empty() || key.compare(right_most_key) <= 0) { 
 
       Slice left_most_key(get_lmost_key(nodes));
 
-      if (key.compare(left_most_key) >= 0)
+    // Left most key is "" or key is greater than or equal to left most key. 
+      if (left_most_key.empty() || key.compare(left_most_key) >= 0)
         return nodes;
       else 
         return nullptr;
@@ -48,18 +52,49 @@ PartitionTreeNode *PartitionTreeNode::SearchNextNode (
   return nullptr;
 }
 
+void PartitionTreeNode::Print(
+    std::string TreeID, 
+    bool recursive) {
+
+  fprintf(stdout, "%-6s LCF[%d] %s => [%s, %s)\n", 
+    TreeID.c_str(), cfd_->GetID(), cfd_->GetName().c_str(), 
+    cfd_->GetSmallestKey().c_str(), cfd_->GetLargestKey().c_str());
+
+  if (!recursive) 
+    return;
+
+  uint32_t i = 0; 
+  for (auto nodes: lower_level_nodes_) 
+    nodes->Print(TreeID + std::to_string(i++), true);
+}
+
+
 // PartitionTree function.
+
+PartitionTree::PartitionTree( 
+    ColumnFamilyData* column_family_data) : root_(column_family_data) {
+
+  fprintf(stdout, "Insert New CFD %d\n", column_family_data->GetID());
+
+  partition_nodes_.insert({column_family_data->GetID(), &root_}); 
+}
 
 void PartitionTree::SetRootColumnFamily (
     ColumnFamilyData* column_family_data) {
   root_.SetColumnFamily(column_family_data);
+
+  fprintf(stdout, "Insert New CFD %d\n", column_family_data->GetID());
+
+  partition_nodes_.insert(
+    std::make_pair<uint32_t, PartitionTreeNode*>(column_family_data->GetID(), &root_));
 }
 
 void PartitionTree::InsertSplittedColumnFamily (
     ColumnFamilyData *base_cfd, 
     const std::vector<ColumnFamilyData*> &new_cfds) {
 
-  auto base_node = partition_nodes_.find(base_cfd->GetID())->second;
+  auto base_node_iter = partition_nodes_.find(base_cfd->GetID());
+  auto base_node = base_node_iter->second;
   bool push_back = base_node->lower_level_nodes_.empty();
 
   // TODO: check violation 1. 
@@ -70,6 +105,8 @@ void PartitionTree::InsertSplittedColumnFamily (
   // with respect to its key range. 
   for (auto new_cfd: new_cfds) {
     auto node = new PartitionTreeNode(new_cfd);
+
+    fprintf(stdout, "Insert New CFD[%d] %s\n", new_cfd->GetID(), new_cfd->GetName().c_str());
 
     if (push_back) {
       base_node->lower_level_nodes_.push_back(node);
@@ -93,9 +130,16 @@ ColumnFamilyData* PartitionTree::SearchColumnFamily (const Slice &key) {
     cnode = nnode; 
   }
 
+  /*
+  fprintf(stdout, "CFD[%s] Search... %s < [%s] < %s\n", 
+    cnode->cfd_->GetName().c_str(), get_lmost_key(cnode).c_str(), key.data(), get_rmost_key(cnode).c_str());
+  */
   return cnode->cfd_;
 }
   
+void PartitionTree::PrintAll() {
+  root_.Print("0", true);
+}
  
 }
 

--- a/db/partition_tree.cc
+++ b/db/partition_tree.cc
@@ -1,0 +1,104 @@
+// Author: Dohyun Kim (ehgus421210@kaist.ac.kr)
+// Note: Partition tree for logical column family.
+//
+
+#include "db/partition_tree.h"
+
+#define get_lmost_key(n) ((n)->cfd_->GetSmallestKey())
+#define get_rmost_key(n) ((n)->cfd_->GetLargestKey())
+
+namespace rocksdb {
+
+PartitionTreeNode::PartitionTreeNode (
+    ColumnFamilyData *column_family_data) 
+    : cfd_(column_family_data) {
+
+  if (cfd_ == nullptr) { 
+    // TODO: error raise should be added. 
+    return; 
+  }
+} 
+
+void PartitionTreeNode::SetColumnFamily (
+    ColumnFamilyData* column_family_data) {
+  cfd_ = column_family_data;
+}
+
+PartitionTreeNode *PartitionTreeNode::SearchNextNode (
+    const Slice &key) {
+    
+  if (lower_level_nodes_.empty()) 
+    return nullptr;
+
+  // Linear Search
+  for (auto nodes: lower_level_nodes) {
+    Slice right_most_key(get_rmost_key(nodes));
+
+    if (key.compare(right_most_key) =< 0) { 
+
+      Slice left_most_key(get_lmost_key(nodes));
+
+      if (key.compare(left_most_key) >= 0)
+        return nodes;
+      else 
+        return nullptr;
+    }
+  }
+
+  return nullptr;
+}
+
+// PartitionTree function.
+
+void PartitionTree::SetColumnFamily (
+    ColumnFamilyData* column_family_data) {
+  root_.SetColumnFamily(column_family_data);
+}
+
+void PartitionTree::InsertSplittedColumnFamily (
+    ColumnFamilyData *base_cfd, 
+    const std::vector<ColumnFamilyData*> &new_cfds) {
+
+  auto base_node = partition_nodes_.find(base_cfd->GetID());
+  bool push_back = base_node->lower_level_cfds_.empty();
+
+  // TODO: check violation 1. 
+  // Violation 1. The key range of splitted nodes under the base should be 
+  // included in the key range of base column family. 
+
+  // Note: We assume that the vector new_cfds already sorted 
+  // with respect to its key range. 
+  for (auto new_cfd: new_cfds) {
+    auto node = new PartitionTreeNode(new_cfd);
+
+    if (push_back) {
+      base_node->lower_level_cfds_.push_back(node);
+      continue;
+    } 
+
+    //...
+  }
+}
+
+ColumnFamilyData *SearchColumnFamily (const Slice &key) {
+  PartitionTreeNode *cnode = &root_; // current node
+  PartitionTreeNode *nnode = nullptr; // next node
+
+  while (true) {
+    nnode = cnode->SearchNextNode(key);
+
+    if (nnode == nullptr) 
+      break; 
+
+    cnode = nnode; 
+  }
+
+  return cnode->cfd_;
+}
+  
+ 
+}
+
+
+
+

--- a/db/partition_tree.h
+++ b/db/partition_tree.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include <atomic>
+#include <iostream>
 
 #include "db/column_family.h"
 
@@ -26,6 +27,8 @@ class PartitionTreeNode {
 
   void SetColumnFamily(ColumnFamilyData*);
   PartitionTreeNode *SearchNextNode(const Slice &key);
+
+  void Print(std::string TreeID, bool recursive);
 };
 
 class PartitionTree {
@@ -35,13 +38,14 @@ class PartitionTree {
   std::unordered_map<uint32_t, PartitionTreeNode*> partition_nodes_;
 
   PartitionTree() {};
-  PartitionTree(ColumnFamilyData *cfd) : root_(cfd) {};
+  PartitionTree(ColumnFamilyData *cfd);
   ~PartitionTree() {};
 
   void SetRootColumnFamily(ColumnFamilyData*);
   void InsertSplittedColumnFamily (ColumnFamilyData *base_cfd, const std::vector<ColumnFamilyData*> &new_cfds);
   ColumnFamilyData *SearchColumnFamily (const Slice &key); 
   
+  void PrintAll();
 };
 
 }

--- a/db/partition_tree.h
+++ b/db/partition_tree.h
@@ -22,7 +22,7 @@ class PartitionTreeNode {
   std::vector<PartitionTreeNode*> lower_level_nodes_;
   
   PartitionTreeNode() {};
-  PartitionTreeNode(ColumnFamilyData*) {};
+  PartitionTreeNode(ColumnFamilyData*); 
 
   void SetColumnFamily(ColumnFamilyData*);
   PartitionTreeNode *SearchNextNode(const Slice &key);
@@ -39,7 +39,7 @@ class PartitionTree {
   ~PartitionTree() {};
 
   void SetRootColumnFamily(ColumnFamilyData*);
-  void InsertSplittedColumnFamily (ColumnFamilyData *base_cfd, const std::vector<ColumnFamilyData*> new_cfds);
+  void InsertSplittedColumnFamily (ColumnFamilyData *base_cfd, const std::vector<ColumnFamilyData*> &new_cfds);
   ColumnFamilyData *SearchColumnFamily (const Slice &key); 
   
 };

--- a/db/partition_tree.h
+++ b/db/partition_tree.h
@@ -1,0 +1,53 @@
+// Author: Dohyun Kim (ehgus421210@kaist.ac.kr)
+// Note: Partition tree for logical column family.
+// 
+
+#pragma once 
+
+#include <string>
+#include <vector>
+#include <atomic>
+
+#include "db/column_family.h"
+
+namespace rocksdb {
+
+class ColumnFamilyData;
+
+class PartitionTreeNode {
+ public:
+  
+  ColumnFamilyData *cfd_ = nullptr;
+
+  std::vector<PartitionTreeNode*> lower_level_nodes_;
+  
+  PartitionTreeNode() {};
+  PartitionTreeNode(ColumnFamilyData*) {};
+
+  void SetColumnFamily(ColumnFamilyData*);
+  PartitionTreeNode *SearchNextNode(const Slice &key);
+};
+
+class PartitionTree {
+ public:
+
+  PartitionTreeNode root_;
+  std::unordered_map<uint32_t, PartitionTreeNode*> partition_nodes_;
+
+  PartitionTree() {};
+  PartitionTree(ColumnFamilyData *cfd) : root_(cfd) {};
+  ~PartitionTree() {};
+
+  void SetRootColumnFamily(ColumnFamilyData*);
+  void InsertSplittedColumnFamily (ColumnFamilyData *base_cfd, const std::vector<ColumnFamilyData*> new_cfds);
+  ColumnFamilyData *SearchColumnFamily (const Slice &key); 
+  
+};
+
+}
+
+
+
+
+
+

--- a/db/split_job.cc
+++ b/db/split_job.cc
@@ -817,6 +817,7 @@ void SplitJob::ProcessKeyValueSplit(SubsplitState* sub_split) {
     // going to be 1.2MB and max_output_file_size = 1MB, prefer to have 0.6MB
     // and 0.6MB instead of 1MB and 0.2MB)
     bool output_file_ended = false;
+    bool write_left_ended = false;
     Status input_status;
     if (sub_split->compaction->output_level() != 0 &&
         sub_split->current_output_file_size >=
@@ -825,6 +826,10 @@ void SplitJob::ProcessKeyValueSplit(SubsplitState* sub_split) {
       // status before advancing will be given to FinishSplitOutputFile().
       input_status = input->status();
       output_file_ended = true;
+      ROCKS_LOG_INFO(
+          db_options_.info_log,
+          "SplitJob::ProcessKeyValueSplit output_file_ended(1)"
+      );
     }
     c_iter->Next();
     if (!output_file_ended && c_iter->Valid() &&
@@ -837,11 +842,19 @@ void SplitJob::ProcessKeyValueSplit(SubsplitState* sub_split) {
       // FinishSplitOutputFile().
       input_status = input->status();
       output_file_ended = true;
+      ROCKS_LOG_INFO(
+          db_options_.info_log,
+          "SplitJob::ProcessKeyValueSplit output_file_ended(2)"
+      );
     }
     if (sub_split->write_left && cfd->user_comparator()->Compare(c_iter->user_key(), sub_split->median_key) >=0) {
       // (3) if key is greater than the median, terminates the file and switch to the next column family.
-      sub_split->write_left = false;
+      write_left_ended = true;
       output_file_ended = true;
+      ROCKS_LOG_INFO(
+          db_options_.info_log,
+          "SplitJob::ProcessKeyValueSplit output_file_ended(3)"
+      );
     }
 
     if (output_file_ended) {
@@ -855,6 +868,9 @@ void SplitJob::ProcessKeyValueSplit(SubsplitState* sub_split) {
                                      &range_del_out_stats, next_key);
       RecordDroppedKeys(range_del_out_stats,
                         &sub_split->split_job_stats);
+      if (write_left_ended) {
+        sub_split->write_left = false;
+      }
     }
   }
 
@@ -987,6 +1003,12 @@ Status SplitJob::FinishSplitOutputFile(
 
   ColumnFamilyData* cfd = sub_split->write_left ? sub_split->cfd_out0 : sub_split->cfd_out1;
   const Comparator* ucmp = cfd->user_comparator();
+  ROCKS_LOG_INFO(
+      db_options_.info_log,
+      "SplitJob::FinishSplitOutputFile write_left : %d\n",
+      sub_split->write_left
+  );
+
 
   // Check for iterator errors
   Status s = input_status;

--- a/db/split_picker.cc
+++ b/db/split_picker.cc
@@ -98,6 +98,8 @@ bool SplitPicker::NeedsSplit(const VersionStorageInfo* vstorage) {
   ROCKS_LOG_INFO(ioptions_.info_log,
                      "NeedsSplit: level1 file count : %d", (int)vstorage->LevelFiles(1).size());
 
+  assert(vstorage->LevelFiles(1).size() >=4);
+
   if (vstorage->LevelFiles(1).size() >= 4) {
     // For test, we assume the cf is splitted if l0 count >= 4,
     // instead of L0->L1 compaction

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1195,7 +1195,6 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
                   bool* is_blob) {
   Slice ikey = k.internal_key();
   Slice user_key = k.user_key();
-
   assert(status->ok() || status->IsMergeInProgress());
 
   if (key_exists != nullptr) {
@@ -1260,6 +1259,8 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
     switch (get_context.State()) {
       case GetContext::kNotFound:
         // Keep searching in other files
+        ROCKS_LOG_INFO(info_log_,
+                     "VersionGetImpl: notfound");
         break;
       case GetContext::kMerge:
         // TODO: update per-level perfcontext user_key_return_count for kMerge
@@ -1273,6 +1274,8 @@ void Version::Get(const ReadOptions& read_options, const LookupKey& k,
           RecordTick(db_statistics_, GET_HIT_L2_AND_UP);
         }
         PERF_COUNTER_BY_LEVEL_ADD(user_key_return_count, 1, fp.GetHitFileLevel());
+        ROCKS_LOG_INFO(info_log_,
+                     "VersionGetImpl: found");
         return;
       case GetContext::kDeleted:
         // Use empty error message for speed

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1178,6 +1178,11 @@ class MemTableInserter : public WriteBatch::Handler {
     }
   }
 
+  bool SeekToColumnFamilyByKey(const Slice &key, Status* s) {
+    auto cfd = cf_mems_->SeekLogicalColumnFamily(key);
+    return SeekToColumnFamily(cfd->GetID(), s);
+  }
+
   bool SeekToColumnFamily(uint32_t column_family_id, Status* s) {
     // If we are in a concurrent mode, it is the caller's responsibility
     // to clone the original ColumnFamilyMemTables so that each thread
@@ -1228,7 +1233,8 @@ class MemTableInserter : public WriteBatch::Handler {
     }
 
     Status seek_status;
-    if (UNLIKELY(!SeekToColumnFamily(column_family_id, &seek_status))) {
+    //if (UNLIKELY(!SeekToColumnFamily(column_family_id, &seek_status))) {
+    if (UNLIKELY(!SeekToColumnFamilyByKey(key, &seek_status))) {
       bool batch_boundry = false;
       if (rebuilding_trx_ != nullptr) {
         assert(!write_after_commit_);

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -33,6 +33,7 @@ class ColumnFamilyMemTables {
   virtual MemTable* GetMemTable() const = 0;
   virtual ColumnFamilyHandle* GetColumnFamilyHandle() = 0;
   virtual ColumnFamilyData* current() { return nullptr; }
+  virtual ColumnFamilyData* SeekLogicalColumnFamily(const Slice &key) = 0; 
 };
 
 class ColumnFamilyMemTablesDefault : public ColumnFamilyMemTables {
@@ -53,6 +54,10 @@ class ColumnFamilyMemTablesDefault : public ColumnFamilyMemTables {
   }
 
   ColumnFamilyHandle* GetColumnFamilyHandle() override { return nullptr; }
+
+  ColumnFamilyData* SeekLogicalColumnFamily(const Slice &key) {
+    return (key.size() == 0) ? current() : nullptr;
+  }
 
  private:
   bool ok_;

--- a/src.mk
+++ b/src.mk
@@ -15,6 +15,7 @@ LIB_SOURCES =                                                   \
   db/compaction_picker_universal.cc                             \
   db/split_job.cc        			                                  \
   db/split_picker.cc          		                              \
+  db/partition_tree.cc          		                            \
   db/convenience.cc                                             \
   db/db_filesnapshot.cc                                         \
   db/db_impl.cc                                                 \

--- a/table/sst_file_split_test.cc
+++ b/table/sst_file_split_test.cc
@@ -7,6 +7,8 @@
 
 #include <inttypes.h>
 #include <iostream>
+#include <sstream>
+#include <iomanip>
 
 #include "db/db_impl.h"
 #include "rocksdb/db.h"
@@ -427,14 +429,21 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
   std::cout << "[SplitTest] keys4 [" << EncodeAsString(kNumKeys*3) << ", " << EncodeAsString(4*kNumKeys-1) << "]"<<std::endl;
   
   std::vector<std::string> keys5;
-  for (uint64_t i = kNumKeys/2; i < 4*kNumKeys; i++) {
+  for (uint64_t i = kNumKeys/2; i < 4*kNumKeys - kNumKeys/2; i++) {
     keys5.emplace_back(EncodeAsString(i));
   }
-  std::cout << "[SplitTest] keys5 [" << EncodeAsString(kNumKeys/2) << ", " << EncodeAsString(4*kNumKeys-1) << "]"<<std::endl;
+  std::cout << "[SplitTest] keys5 [" << EncodeAsString(kNumKeys/2) << ", " << EncodeAsString(4*kNumKeys- kNumKeys/2 - 1) << "]"<<std::endl;
 
   // Ingest the file into a db, to assign it a global sequence number.
   Options options;
   options.create_if_missing = true;
+
+  options.compaction_style = kCompactionStyleLevel;
+  options.num_levels = 1;
+  options.write_buffer_size = 256 << 20;
+  options.target_file_size_base = 1024*1024;
+  options.level0_file_num_compaction_trigger = 1;
+
   std::string db_name = test::PerThreadDBPath("test_db");
   DB* db;
   ASSERT_OK(DB::Open(options, db_name, &db));
@@ -496,10 +505,41 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
     fprintf(stdout,"[childrencfd] %s : largest key : %s\n", c->GetName().c_str(), c->GetLargestKey().c_str());
   }
 
-
   std::string value1, value2, value3;
   std::string value12, value22, value32;
   std::string value13, value23, value33;
+
+  // pair : {TestName, key}
+  std::vector<std::pair<std::string, uint32_t>> GetTestKey 
+    = {{"SSTtable search (key < median)", kNumKeys/4},
+       {"SSTtable search (key > median)", 4*kNumKeys - kNumKeys/4},
+       {"Memtable search (key < median)", 2*kNumKeys - 1},
+       {"Memtable search (key == median)", 2*kNumKeys},
+       {"Memtable search (key > median)", 2*kNumKeys + 1}};
+  
+  for (auto p: GetTestKey) {
+    std::ostringstream ss;
+    ss << std::setw(8) << std::setfill('0') << p.second;
+    std::string key = ss.str();
+    std::string test_name = p.first; 
+    std::string value; 
+    Status s; 
+
+    s = db->Get(ReadOptions(), cfh, key, &value);
+   
+    fprintf(stdout, "[SplitTest] [%s] Key [%s] ", test_name.c_str(), key.c_str());
+
+    if (s.IsNotFound())
+      fprintf(stdout, "Not Found...\n");
+    if (s.ok())
+      fprintf(stdout, "==> %s\n", value.c_str());
+  }
+  
+  /*
+  std::string value1, value2, value3;
+  std::string value12, value22, value32;
+  std::string value13, value23, value33;
+
   db->Get(ReadOptions(), cfh, "00001999", &value1);
   db->Get(ReadOptions(), cfh1, "00001999",&value2);
   db->Get(ReadOptions(), cfh2, "00001999", &value3);
@@ -519,9 +559,6 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
   fprintf(stdout,"[SplitTest] cf01 : smallest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh2)->cfd()->GetSmallestKey().c_str());
   fprintf(stdout,"[SplitTest] cf01 : largest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh2)->cfd()->GetLargestKey().c_str());
 
-
-
-
   fprintf(stdout,"[SplitTest] cf0 : key less than median(00001999) -> %s\n", value1.c_str());
   fprintf(stdout,"[SplitTest] cf00 : key less than median(00001999) -> %s\n", value2.c_str());
   fprintf(stdout,"[SplitTest] cf01 : key less than median(00001999) -> %s\n", value3.c_str());
@@ -535,10 +572,11 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
   fprintf(stdout,"[SplitTest] cf01 : key median -> %s\n", value33.c_str());
  
   dbfull(db)->PrintLogicalColumnFamily();
-  /*auto lcf = dbfull(db)->GetLogicalColumnFamily();
+  auto lcf = dbfull(db)->GetLogicalColumnFamily();
   for (auto l: lcf) {
     fprintf(stdout, "[SplitTest] LCF[%d] %s => [%s, %s)\n", l->GetID(), l->GetName().c_str(), l->GetSmallestKey().c_str(), l->GetLargestKey().c_str());
   }*/
+
   //db->DropColumnFamily(cfh);
   db->DestroyColumnFamilyHandle(cfh1);
   db->DestroyColumnFamilyHandle(cfh2);

--- a/table/sst_file_split_test.cc
+++ b/table/sst_file_split_test.cc
@@ -451,16 +451,6 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
   // create column family
   std::cout << "[SplitTest] create cf : cf0" << std::endl;
   ColumnFamilyHandle* cfh = db->DefaultColumnFamily();
-  /*std::string cf_name = "cf0";
-
-  std::unique_ptr<ColumnFamilyOptions> cfo(new ColumnFamilyOptions());
-  cfo->compaction_style = kCompactionStyleLevel;
-  cfo->num_levels = 2;
-  cfo->write_buffer_size = 64 << 20; // 64 MB
-  cfo->target_file_size_base = 1024*1024; // 1MB
-  cfo->level0_file_num_compaction_trigger = 4; 
-
-  db->CreateColumnFamily(*(cfo.get()), cf_name, &cfh);*/
 
   // Generate a SST file.
   CreateMT(db, cfh, keys);
@@ -511,8 +501,8 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
 
   // pair : {TestName, key}
   std::vector<std::pair<std::string, uint32_t>> GetTestKey 
-    = {{"SSTtable search (key < median)", kNumKeys/4},
-       {"SSTtable search (key > median)", 4*kNumKeys - kNumKeys/4},
+    = {{"SSTtable search (key < median)", kNumKeys/2},
+       {"SSTtable search (key > median)", 4*kNumKeys - kNumKeys/2 - 1},
        {"Memtable search (key < median)", 2*kNumKeys - 1},
        {"Memtable search (key == median)", 2*kNumKeys},
        {"Memtable search (key > median)", 2*kNumKeys + 1}};
@@ -535,52 +525,14 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
     if (s.ok())
       fprintf(stdout, "==> %s\n", value.c_str());
   }
-  fprintf(stdout, "[Search in cfh1\n");
-  for (auto p: GetTestKey) {
-    std::ostringstream ss;
-    ss << std::setw(8) << std::setfill('0') << p.second;
-    std::string key = ss.str();
-    std::string test_name = p.first; 
-    std::string value; 
-    Status s; 
 
-    s = db->Get(ReadOptions(), cfh1, key, &value);
-   
-    fprintf(stdout, "[SplitTest] [%s] Key [%s] ", test_name.c_str(), key.c_str());
-
-    if (s.IsNotFound())
-      fprintf(stdout, "Not Found...\n");
-    if (s.ok())
-      fprintf(stdout, "==> %s\n", value.c_str());
-  }
-  fprintf(stdout, "[Search in cfh2\n");
-  for (auto p: GetTestKey) {
-    std::ostringstream ss;
-    ss << std::setw(8) << std::setfill('0') << p.second;
-    std::string key = ss.str();
-    std::string test_name = p.first; 
-    std::string value; 
-    Status s; 
-
-    s = db->Get(ReadOptions(), cfh2, key, &value);
-   
-    fprintf(stdout, "[SplitTest] [%s] Key [%s] ", test_name.c_str(), key.c_str());
-
-    if (s.IsNotFound())
-      fprintf(stdout, "Not Found...\n");
-    if (s.ok())
-      fprintf(stdout, "==> %s\n", value.c_str());
-  }
- 
-  
-
-  //db->DropColumnFamily(cfh);
   db->DropColumnFamily(cfh1);
   db->DropColumnFamily(cfh2);
-  // db->DestroyColumnFamilyHandle(cfh); // Default column family automatically removed when the dbimpl is removed. 
   delete db;
 }
-/*
+
+
+
 TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped2) {
   // put even digits to the sstables
   std::vector<std::string> keys;
@@ -680,15 +632,15 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped2) {
 
   // pair : {TestName, key}
   std::vector<std::pair<std::string, uint32_t>> GetTestKey 
-    = {{"SSTtable search (odd key < median)", kNumKeys/2 + 1},
-       {"SSTtable search (odd key > median)", 4*kNumKeys + kNumKeys/2 + 1},
+    = {{"Memtable search (odd key < median)", kNumKeys + 1},
+       {"Memtable search (odd key > median)", 4*kNumKeys + kNumKeys/2 + 1},
        {"Memtable search (odd key < median)", 4*kNumKeys - kNumKeys/2 + 1},
        {"Memtable search (odd key > median)", 4*kNumKeys + 1},
-       {"SSTtable search (even key < median)", kNumKeys/4},
-       {"SSTtable search (even key > median)", 4*kNumKeys + kNumKeys/2},
-       {"Memtable search (even key < median)", 4*kNumKeys - 2},
-       {"Memtable search (even == median)", 4*kNumKeys},
-       {"Memtable search (even key > median)", 4*kNumKeys + 2}};
+       {"SSTable search (even key < median)", kNumKeys/4},
+       {"SSTable search (even key > median)", 4*kNumKeys + kNumKeys/2},
+       {"SSTable search (even key < median)", 4*kNumKeys - 2},
+       {"SSTable search (even == median)", 4*kNumKeys},
+       {"SSTable search (even key > median)", 4*kNumKeys + 2}};
   
   for (auto p: GetTestKey) {
     std::ostringstream ss;
@@ -716,7 +668,7 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped2) {
   // db->DestroyColumnFamilyHandle(cfh); // Default column family automatically removed when the dbimpl is removed. 
 
   delete db;
-}*/
+}
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/table/sst_file_split_test.cc
+++ b/table/sst_file_split_test.cc
@@ -354,6 +354,7 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultiple) {
   delete db;
 }
 */
+/*
 TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
   std::vector<std::string> keys;
   for (uint64_t i = 0; i < kNumKeys; i++) {
@@ -400,8 +401,8 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
   db->DestroyColumnFamilyHandle(cfh);
 
   delete db;
-}
-/*
+}*/
+
 TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
   std::vector<std::string> keys;
   for (uint64_t i = 0; i < kNumKeys; i++) {
@@ -431,8 +432,6 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
   }
   std::cout << "[SplitTest] keys5 [" << EncodeAsString(kNumKeys/2) << ", " << EncodeAsString(4*kNumKeys-1) << "]"<<std::endl;
 
-
-
   // Ingest the file into a db, to assign it a global sequence number.
   Options options;
   options.create_if_missing = true;
@@ -442,16 +441,17 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
 
   // create column family
   std::cout << "[SplitTest] create cf : cf0" << std::endl;
-  ColumnFamilyHandle* cfh;
-  std::string cf_name = "cf0";
+  ColumnFamilyHandle* cfh = db->DefaultColumnFamily();
+  /*std::string cf_name = "cf0";
 
   std::unique_ptr<ColumnFamilyOptions> cfo(new ColumnFamilyOptions());
   cfo->compaction_style = kCompactionStyleLevel;
-  cfo->num_levels = 1;
+  cfo->num_levels = 2;
   cfo->write_buffer_size = 64 << 20; // 64 MB
-  cfo->level0_file_num_compaction_trigger = 1; 
+  cfo->target_file_size_base = 1024*1024; // 1MB
+  cfo->level0_file_num_compaction_trigger = 4; 
 
-  db->CreateColumnFamily(*(cfo.get()), cf_name, &cfh);
+  db->CreateColumnFamily(*(cfo.get()), cf_name, &cfh);*/
 
   // Generate a SST file.
   CreateMT(db, cfh, keys);
@@ -487,7 +487,7 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
   fprintf(stdout,"[SplitTest] cf01 : largest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh2)->cfd()->GetLargestKey().c_str());
 
 
-  fprintf(stdout,"[SplitTest] wait split\n");
+  fprintf(stdout,"[SplitTest] wait split\n"); 
   dbfull(db)->TEST_WaitForSplit();
   fprintf(stdout,"[SplitTest] wait split done\n");
   
@@ -535,17 +535,17 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
   fprintf(stdout,"[SplitTest] cf01 : key median -> %s\n", value33.c_str());
  
   dbfull(db)->PrintLogicalColumnFamily();
-  auto lcf = dbfull(db)->GetLogicalColumnFamily();
+  /*auto lcf = dbfull(db)->GetLogicalColumnFamily();
   for (auto l: lcf) {
     fprintf(stdout, "[SplitTest] LCF[%d] %s => [%s, %s)\n", l->GetID(), l->GetName().c_str(), l->GetSmallestKey().c_str(), l->GetLargestKey().c_str());
-  }
+  }*/
   //db->DropColumnFamily(cfh);
-  db->DestroyColumnFamilyHandle(cfh);
   db->DestroyColumnFamilyHandle(cfh1);
   db->DestroyColumnFamilyHandle(cfh2);
+  // db->DestroyColumnFamilyHandle(cfh); // Default column family automatically removed when the dbimpl is removed. 
 
   delete db;
-}*/
+}
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/table/sst_file_split_test.cc
+++ b/table/sst_file_split_test.cc
@@ -517,6 +517,179 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
        {"Memtable search (key == median)", 2*kNumKeys},
        {"Memtable search (key > median)", 2*kNumKeys + 1}};
   
+  fprintf(stdout, "[Search in cfh\n");
+  for (auto p: GetTestKey) {
+    std::ostringstream ss;
+    ss << std::setw(8) << std::setfill('0') << p.second;
+    std::string key = ss.str();
+    std::string test_name = p.first; 
+    std::string value; 
+    Status s; 
+
+    s = db->Get(ReadOptions(), cfh, key, &value);
+   
+    fprintf(stdout, "[SplitTest] [%s] Key [%s] ", test_name.c_str(), key.c_str());
+
+    if (s.IsNotFound())
+      fprintf(stdout, "Not Found...\n");
+    if (s.ok())
+      fprintf(stdout, "==> %s\n", value.c_str());
+  }
+  fprintf(stdout, "[Search in cfh1\n");
+  for (auto p: GetTestKey) {
+    std::ostringstream ss;
+    ss << std::setw(8) << std::setfill('0') << p.second;
+    std::string key = ss.str();
+    std::string test_name = p.first; 
+    std::string value; 
+    Status s; 
+
+    s = db->Get(ReadOptions(), cfh1, key, &value);
+   
+    fprintf(stdout, "[SplitTest] [%s] Key [%s] ", test_name.c_str(), key.c_str());
+
+    if (s.IsNotFound())
+      fprintf(stdout, "Not Found...\n");
+    if (s.ok())
+      fprintf(stdout, "==> %s\n", value.c_str());
+  }
+  fprintf(stdout, "[Search in cfh2\n");
+  for (auto p: GetTestKey) {
+    std::ostringstream ss;
+    ss << std::setw(8) << std::setfill('0') << p.second;
+    std::string key = ss.str();
+    std::string test_name = p.first; 
+    std::string value; 
+    Status s; 
+
+    s = db->Get(ReadOptions(), cfh2, key, &value);
+   
+    fprintf(stdout, "[SplitTest] [%s] Key [%s] ", test_name.c_str(), key.c_str());
+
+    if (s.IsNotFound())
+      fprintf(stdout, "Not Found...\n");
+    if (s.ok())
+      fprintf(stdout, "==> %s\n", value.c_str());
+  }
+ 
+  
+
+  //db->DropColumnFamily(cfh);
+  db->DropColumnFamily(cfh1);
+  db->DropColumnFamily(cfh2);
+  // db->DestroyColumnFamilyHandle(cfh); // Default column family automatically removed when the dbimpl is removed. 
+  delete db;
+}
+/*
+TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped2) {
+  // put even digits to the sstables
+  std::vector<std::string> keys;
+  for (uint64_t i = 0; i < kNumKeys; i++) {
+    keys.emplace_back(EncodeAsString(2*i));
+  }
+  std::cout << "[SplitTest] keys(even) [" << EncodeAsString(0) << ", " << EncodeAsString(2*(kNumKeys-1)) << "]"<<std::endl;
+  std::vector<std::string> keys2;
+  for (uint64_t i = kNumKeys; i < 2*kNumKeys; i++) {
+    keys2.emplace_back(EncodeAsString(2*i));
+  }
+  std::cout << "[SplitTest] keys2(even)  [" << EncodeAsString(2*kNumKeys) << ", " << EncodeAsString(2*(2*kNumKeys-1)) << "]"<<std::endl;
+  
+  std::vector<std::string> keys3;
+  for (uint64_t i = kNumKeys*2; i < 3*kNumKeys; i++) {
+    keys3.emplace_back(EncodeAsString(2*i));
+  }
+  std::cout << "[SplitTest] keys3(even)  [" << EncodeAsString(2*(kNumKeys*2)) << ", " << EncodeAsString(2*(3*kNumKeys-1)) << "]"<< std::endl;
+  std::vector<std::string> keys4;
+  for (uint64_t i = 3*kNumKeys; i < 4*kNumKeys; i++) {
+    keys4.emplace_back(EncodeAsString(2*i));
+  }
+  std::cout << "[SplitTest] keys4(even)  [" << EncodeAsString(2*(kNumKeys*3)) << ", " << EncodeAsString(2*(4*kNumKeys-1)) << "]"<<std::endl;
+  
+  // put odd digits to the sstables
+  std::vector<std::string> keys5;
+  for (uint64_t i = kNumKeys/2; i < 4*kNumKeys - kNumKeys/2; i++) {
+    keys5.emplace_back(EncodeAsString(2*i+1));
+  }
+  std::cout << "[SplitTest] keys5(odd)  [" << EncodeAsString(2*(kNumKeys/2)+1) << ", " << EncodeAsString(2*(4*kNumKeys- kNumKeys/2 - 1)+1) << "]"<<std::endl;
+
+  // Ingest the file into a db, to assign it a global sequence number.
+  Options options;
+  options.create_if_missing = true;
+
+  options.compaction_style = kCompactionStyleLevel;
+  options.num_levels = 1;
+  options.write_buffer_size = 256 << 20;
+  options.target_file_size_base = 1024*1024;
+  options.level0_file_num_compaction_trigger = 1;
+
+  std::string db_name = test::PerThreadDBPath("test_db2");
+  DB* db;
+  ASSERT_OK(DB::Open(options, db_name, &db));
+
+  // create column family
+  std::cout << "[SplitTest] create cf : cf0" << std::endl;
+  ColumnFamilyHandle* cfh = db->DefaultColumnFamily();
+
+
+  // Generate a SST file.
+  CreateMT(db, cfh, keys);
+  db->Flush(FlushOptions(), cfh);
+  dbfull(db)->TEST_WaitForCompact();
+  CreateMT(db, cfh, keys2);
+  db->Flush(FlushOptions(), cfh);
+  dbfull(db)->TEST_WaitForCompact();
+  CreateMT(db, cfh, keys3);
+  db->Flush(FlushOptions(), cfh);
+  dbfull(db)->TEST_WaitForCompact();
+  CreateMT(db, cfh, keys4);
+  db->Flush(FlushOptions(), cfh);
+  dbfull(db)->TEST_WaitForCompact();
+
+  CreateMT(db, cfh, keys5);
+
+  ASSERT_EQ(4, GetSstFileCount(db->GetName()));
+  
+  // Split
+  ColumnFamilyHandle *cfh1, *cfh2;
+  std::cout << "[SplitTest] split cf : cf0" << std::endl;
+  const char* median_key = (reinterpret_cast<ColumnFamilyHandleImpl*> (cfh))->cfd()->current()->storage_info()->GetMedianKey().ToString().c_str() ;
+  std::cout << "[SplitTest] median key : " << median_key << std::endl;
+
+  dbfull(db)->PrintLogicalColumnFamily();
+  db->SplitColumnFamily(ColumnFamilyOptions(), &cfh, &cfh1, &cfh2);
+ 
+  fprintf(stdout,"[SplitTest] cf00 : smallest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh1)->cfd()->GetSmallestKey().c_str());
+  fprintf(stdout,"[SplitTest] cf00 : largest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh1)->cfd()->GetLargestKey().c_str());
+ 
+  fprintf(stdout,"[SplitTest] cf01 : smallest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh2)->cfd()->GetSmallestKey().c_str());
+  fprintf(stdout,"[SplitTest] cf01 : largest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh2)->cfd()->GetLargestKey().c_str());
+
+
+  fprintf(stdout,"[SplitTest] wait split\n"); 
+  dbfull(db)->TEST_WaitForSplit();
+  fprintf(stdout,"[SplitTest] wait split done\n");
+  
+  for (auto c: static_cast<ColumnFamilyHandleImpl*>(cfh)->cfd()->children_cfds) {
+    fprintf(stdout,"[childrencfd] %s : smallest key :  %s\n", c->GetName().c_str(), c->GetSmallestKey().c_str());
+    fprintf(stdout,"[childrencfd] %s : largest key : %s\n", c->GetName().c_str(), c->GetLargestKey().c_str());
+  }
+
+  std::string value1, value2, value3;
+  std::string value12, value22, value32;
+  std::string value13, value23, value33;
+
+  // pair : {TestName, key}
+  std::vector<std::pair<std::string, uint32_t>> GetTestKey 
+    = {{"SSTtable search (odd key < median)", kNumKeys/2 + 1},
+       {"SSTtable search (odd key > median)", 4*kNumKeys + kNumKeys/2 + 1},
+       {"Memtable search (odd key < median)", 4*kNumKeys - kNumKeys/2 + 1},
+       {"Memtable search (odd key > median)", 4*kNumKeys + 1},
+       {"SSTtable search (even key < median)", kNumKeys/4},
+       {"SSTtable search (even key > median)", 4*kNumKeys + kNumKeys/2},
+       {"Memtable search (even key < median)", 4*kNumKeys - 2},
+       {"Memtable search (even == median)", 4*kNumKeys},
+       {"Memtable search (even key > median)", 4*kNumKeys + 2}};
+  
   for (auto p: GetTestKey) {
     std::ostringstream ss;
     ss << std::setw(8) << std::setfill('0') << p.second;
@@ -535,55 +708,15 @@ TEST_F(SstFileSplitTest, SplitColumnFamilyMultipleOverlapped) {
       fprintf(stdout, "==> %s\n", value.c_str());
   }
   
-  /*
-  std::string value1, value2, value3;
-  std::string value12, value22, value32;
-  std::string value13, value23, value33;
 
-  db->Get(ReadOptions(), cfh, "00001999", &value1);
-  db->Get(ReadOptions(), cfh1, "00001999",&value2);
-  db->Get(ReadOptions(), cfh2, "00001999", &value3);
-  db->Get(ReadOptions(), cfh, "00002001", &value12);
-  db->Get(ReadOptions(), cfh1, "00002001",&value22);
-  db->Get(ReadOptions(), cfh2, "00002001", &value32);
-  db->Get(ReadOptions(), cfh, "00002000", &value13);
-  db->Get(ReadOptions(), cfh1, "00002000",&value23);
-  db->Get(ReadOptions(), cfh2, "00002000", &value33);
-  
-  fprintf(stdout,"[SplitTest] cf0 : smallest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh)->cfd()->GetSmallestKey().c_str());
-  fprintf(stdout,"[SplitTest] cf0 : largest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh)->cfd()->GetLargestKey().c_str());
- 
-  fprintf(stdout,"[SplitTest] cf00 : smallest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh1)->cfd()->GetSmallestKey().c_str());
-  fprintf(stdout,"[SplitTest] cf00 : largest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh1)->cfd()->GetLargestKey().c_str());
- 
-  fprintf(stdout,"[SplitTest] cf01 : smallest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh2)->cfd()->GetSmallestKey().c_str());
-  fprintf(stdout,"[SplitTest] cf01 : largest key :  -> %s\n", static_cast<ColumnFamilyHandleImpl*>(cfh2)->cfd()->GetLargestKey().c_str());
-
-  fprintf(stdout,"[SplitTest] cf0 : key less than median(00001999) -> %s\n", value1.c_str());
-  fprintf(stdout,"[SplitTest] cf00 : key less than median(00001999) -> %s\n", value2.c_str());
-  fprintf(stdout,"[SplitTest] cf01 : key less than median(00001999) -> %s\n", value3.c_str());
-   
-  fprintf(stdout,"[SplitTest] cf0 : key greater than median(00002001) -> %s\n", value12.c_str());
-  fprintf(stdout,"[SplitTest] cf00 : key greater than median(00002001) -> %s\n", value22.c_str());
-  fprintf(stdout,"[SplitTest] cf01 : key greater than median(00002001) -> %s\n", value32.c_str());
-  
-  fprintf(stdout,"[SplitTest] cf0 : key median -> %s\n", value13.c_str());
-  fprintf(stdout,"[SplitTest] cf00 : key median -> %s\n", value23.c_str());
-  fprintf(stdout,"[SplitTest] cf01 : key median -> %s\n", value33.c_str());
- 
-  dbfull(db)->PrintLogicalColumnFamily();
-  auto lcf = dbfull(db)->GetLogicalColumnFamily();
-  for (auto l: lcf) {
-    fprintf(stdout, "[SplitTest] LCF[%d] %s => [%s, %s)\n", l->GetID(), l->GetName().c_str(), l->GetSmallestKey().c_str(), l->GetLargestKey().c_str());
-  }*/
 
   //db->DropColumnFamily(cfh);
-  db->DestroyColumnFamilyHandle(cfh1);
-  db->DestroyColumnFamilyHandle(cfh2);
+  db->DropColumnFamily(cfh1);
+  db->DropColumnFamily(cfh2);
   // db->DestroyColumnFamilyHandle(cfh); // Default column family automatically removed when the dbimpl is removed. 
 
   delete db;
-}
+}*/
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {

--- a/tools/db_bench.cc
+++ b/tools/db_bench.cc
@@ -19,5 +19,6 @@ int main() {
 }
 #else
 #include <rocksdb/db_bench_tool.h>
-int main(int argc, char** argv) { return rocksdb::db_bench_tool(argc, argv); }
+//int main(int argc, char** argv) { return rocksdb::db_bench_tool(argc, argv); }
+int main() { return 0; }
 #endif  // GFLAGS


### PR DESCRIPTION
Implement logical partition tree into current branch "background_split_test-wip"
By now, class ColumnFamilySet contains member named logical_column_family_data_, which manages the splitted column families.
We replace them with partition tree, which is already implemented in the branch "lcf_partition_tree_0905"